### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -2,6 +2,8 @@ name: Stamp Release Assets
 on:
   release:
     types: [published]
+permissions:
+  contents: read
 jobs:
   stamp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SinAi-Inc/istampit-action/security/code-scanning/1](https://github.com/SinAi-Inc/istampit-action/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the workflow only checks out code, runs a local action, and uploads artifacts, it likely only needs read access to repository contents. The minimal fix is to add `permissions: contents: read` at the workflow level (above `jobs:`), which will apply to all jobs unless overridden. This change should be made at the top of the file, after the `name:` and `on:` blocks, and before `jobs:`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
