### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   stamp-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SinAi-Inc/istampit-action/security/code-scanning/4](https://github.com/SinAi-Inc/istampit-action/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/self-test.yml`. The block should be placed at the root level (above `jobs:`) to apply to all jobs in the workflow, unless a job needs more specific permissions. For this workflow, the minimal required permission is `contents: read`, as none of the steps require write access to repository contents or other resources. No additional imports or definitions are needed; simply add the block in the correct location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
