### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: Example iStampit Action
+permissions:
+  contents: read
 on: [push]
 jobs:
   stamp:


### PR DESCRIPTION
Potential fix for [https://github.com/SinAi-Inc/istampit-action/security/code-scanning/2](https://github.com/SinAi-Inc/istampit-action/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow does not appear to require any write access (it checks out code, creates a file, runs a local action, and verifies file existence), the minimal permission of `contents: read` is appropriate. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions. The change should be made by adding a `permissions:` block after the `name:` and before the `on:` key in `.github/workflows/example.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
