### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: Self Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SinAi-Inc/istampit-action/security/code-scanning/4](https://github.com/SinAi-Inc/istampit-action/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly set the least privilege required for the `GITHUB_TOKEN`. In this case, the workflow only checks out code, creates a file, and runs a local action, but does not appear to require any write access to repository contents, issues, or pull requests. Therefore, setting `permissions: contents: read` at the workflow level (just after the `name` field and before `on:`) is the best way to address the issue without changing existing functionality. This ensures that all jobs in the workflow inherit these minimal permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
