### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upgrade-nightly.yml
+++ b/.github/workflows/upgrade-nightly.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Nightly Upgrade Dummy Receipt
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/SinAi-Inc/istampit-action/security/code-scanning/3](https://github.com/SinAi-Inc/istampit-action/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. In this case, since the workflow only checks out code and does not perform any write operations, the minimal permission required is `contents: read`. This block should be added at the top level of the workflow file (just after the `name` or `on` block), so it applies to all jobs in the workflow. No changes to the jobs or steps are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
